### PR TITLE
Faster patches

### DIFF
--- a/lib/puppet/provider/ora_opatch/base.rb
+++ b/lib/puppet/provider/ora_opatch/base.rb
@@ -28,7 +28,6 @@ Puppet::Type.type(:ora_opatch).provide(:base) do
     full_command = "export ORACLE_HOME=#{oracle_product_home_dir}; cd #{oracle_product_home_dir}; #{oracle_product_home_dir}/OPatch/opatch #{command}"
     output = Puppet::Util::Execution.execute(full_command, options)
     Puppet.info output
-    fail "Opatch contained an error" unless output=~/OPatch completed|OPatch succeeded|opatch auto succeeded|opatchauto succeeded/
     output
   end
 

--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -31,6 +31,7 @@ define oradb::installasm(
   $cluster_nodes             = undef,
   $network_interface_list    = undef,
   $storage_option            = undef,
+  $response_file_erb         = undef,     
 )
 {
 
@@ -171,10 +172,14 @@ define oradb::installasm(
       os_group          => $group_install,
     }
 
+    if ! defined($response_file_erb) {
+      $response_file_erb = "oradb/grid_install_${version}.rsp.erb";
+    }
+    
     if ! defined(File["${download_dir}/grid_install_${version}.rsp"]) {
       file { "${download_dir}/grid_install_${version}.rsp":
         ensure  => present,
-        content => template("oradb/grid_install_${version}.rsp.erb"),
+        content => template($response_file_erb),
         mode    => '0770',
         owner   => $user,
         group   => $group,

--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -172,7 +172,7 @@ define oradb::installasm(
       os_group          => $group_install,
     }
 
-    if defined($response_file_erb) {
+    if $response_file_erb != undef {
       $r_file_erb = $response_file_erb
     } else {
       $r_file_erb = "oradb/grid_install_${version}.rsp.erb"

--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -172,14 +172,16 @@ define oradb::installasm(
       os_group          => $group_install,
     }
 
-    if ! defined($response_file_erb) {
-      $response_file_erb = "oradb/grid_install_${version}.rsp.erb"
-    }
+    if defined($response_file_erb) {
+      $r_file_erb = $response_file_erb
+    } else {
+      $r_file_erb = "oradb/grid_install_${version}.rsp.erb"
+    } 
     
     if ! defined(File["${download_dir}/grid_install_${version}.rsp"]) {
       file { "${download_dir}/grid_install_${version}.rsp":
         ensure  => present,
-        content => template($response_file_erb),
+        content => template($r_file_erb),
         mode    => '0770',
         owner   => $user,
         group   => $group,

--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -173,7 +173,7 @@ define oradb::installasm(
     }
 
     if ! defined($response_file_erb) {
-      $response_file_erb = "oradb/grid_install_${version}.rsp.erb";
+      $response_file_erb = "oradb/grid_install_${version}.rsp.erb"
     }
     
     if ! defined(File["${download_dir}/grid_install_${version}.rsp"]) {


### PR DESCRIPTION
Hi Bert,
I have been happy with your new type ora_opatch on Solaris x86; however, on Solaris Sparc there are problems.
So I had to modify the function patches_in_home and decided to remove Puppet::Util::Execution.execute altogether (it just did not return output in this case). I did not investigate Puppet::Util::Execution.execute much further because of time-constraints.
The workaround with %x does its jobs well (x86 and Sparc).
regards
Marc
